### PR TITLE
feat(logging): inject logger into request context

### DIFF
--- a/logging/middleware.go
+++ b/logging/middleware.go
@@ -12,15 +12,45 @@ import (
 )
 
 // Middleware is a middleware for writing structured request logs. It uses a chi
-// Chain to make sure all of the deps are properly included (RequestID and
-// Recoverer).
+// Chain to make sure all of the deps are properly included (RequestID,
+// per-request logger injection, and Recoverer).
+//
+// The injected logger is what FromContext returns inside handlers, so
+// downstream code gets the application's configured logger (decorated
+// with the chi request_id) instead of the "unknown" fallback FromContext
+// constructs when the context has no logger.
 func Middleware(log *zap.Logger) func(next http.Handler) http.Handler {
 	return chi.Chain(
 		middleware.RealIP,
 		middleware.RequestID,
+		InjectLogger(log.Sugar()),
 		Handler(log),
 		middleware.Recoverer,
 	).Handler
+}
+
+// InjectLogger attaches base to the request context so handlers calling
+// FromContext receive base (decorated with the chi request_id when
+// present) instead of the "unknown" logger FromContext builds for empty
+// contexts.
+//
+// It is safe to use without chi/middleware.RequestID; in that case the
+// request_id field is simply omitted. A nil base is replaced with a
+// no-op logger so handlers never receive nil.
+func InjectLogger(base *zap.SugaredLogger) func(next http.Handler) http.Handler {
+	if base == nil {
+		base = zap.NewNop().Sugar()
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fields := make([]any, 0, 2)
+			if id, ok := r.Context().Value(middleware.RequestIDKey).(string); ok && id != "" {
+				fields = append(fields, "request_id", id)
+			}
+			ctx := NewContext(r.Context(), base, fields...)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
 }
 
 // Handler does the actual work of the http middleware.

--- a/logging/middleware_test.go
+++ b/logging/middleware_test.go
@@ -1,0 +1,98 @@
+package logging
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// TestMiddlewareInjectsLogger verifies that handlers calling FromContext
+// after Middleware ran get the configured logger (with the chi
+// request_id attached) and not the "unknown" fallback.
+func TestMiddlewareInjectsLogger(t *testing.T) {
+	core, recorded := observer.New(zapcore.InfoLevel)
+	base := zap.New(core).With(zap.String("service", "test"))
+
+	r := chi.NewRouter()
+	r.Use(Middleware(base))
+	r.Get("/", func(w http.ResponseWriter, req *http.Request) {
+		FromContext(req.Context()).Infow("from-handler")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv := httptest.NewServer(r)
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/") //nolint:noctx // test
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Logf("close body: %v", err)
+	}
+
+	entries := recorded.FilterMessage("from-handler").All()
+	if len(entries) != 1 {
+		t.Fatalf("want 1 from-handler entry, got %d (recorded=%d)", len(entries), recorded.Len())
+	}
+	got := entries[0].ContextMap()
+	if got["service"] != "test" {
+		t.Errorf("service = %v, want test", got["service"])
+	}
+	if rid, ok := got["request_id"].(string); !ok || rid == "" {
+		t.Errorf("request_id missing: %#v", got)
+	}
+}
+
+// TestInjectLoggerWithoutRequestID verifies the middleware works
+// standalone (no chi RequestID upstream): the logger is still injected,
+// just without a request_id field.
+func TestInjectLoggerWithoutRequestID(t *testing.T) {
+	core, recorded := observer.New(zapcore.InfoLevel)
+	base := zap.New(core).With(zap.String("service", "test")).Sugar()
+
+	mw := InjectLogger(base)
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		FromContext(req.Context()).Infow("from-handler")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	entries := recorded.FilterMessage("from-handler").All()
+	if len(entries) != 1 {
+		t.Fatalf("want 1 entry, got %d", len(entries))
+	}
+	got := entries[0].ContextMap()
+	if got["service"] != "test" {
+		t.Errorf("service = %v, want test", got["service"])
+	}
+	if _, ok := got["request_id"]; ok {
+		t.Errorf("unexpected request_id field: %v", got["request_id"])
+	}
+}
+
+// TestInjectLoggerNilBase makes sure a nil base does not panic and the
+// handler still runs.
+func TestInjectLoggerNilBase(t *testing.T) {
+	called := false
+	mw := InjectLogger(nil)
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		called = true
+		// FromContext must not return nil even though we passed nil in.
+		if log := FromContext(req.Context()); log == nil {
+			t.Error("FromContext returned nil")
+		}
+	}))
+
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+	if !called {
+		t.Error("handler not called")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `logging.InjectLogger(base)` chi-compatible middleware that puts `base` into the request context via `NewContext`, decorated with the chi `request_id` when `middleware.RequestID` ran upstream.
- Chain `InjectLogger` into `logging.Middleware` between `RequestID` and `Handler` so existing callers automatically benefit.

## Why

Today, handlers calling `logging.FromContext(r.Context())` get the configured logger only if the application installed its own context-injection middleware. When nothing put a logger in the context, `FromContext` builds a brand-new `service=unknown` zap logger on every call:

```go
// logging/context.go
return Must(NewLogger(\"unknown\"))
```

That's expensive (a full `zap.Config{}.Build` per request) and loses the service tag, so every downstream service ends up either reinventing this five-line middleware or — worse — missing it and quietly logging as `service=unknown`.

`InjectLogger` is exposed as a standalone helper so callers that already roll their own request-completion logger (or don't want one) can opt in independently of `Middleware`.

## Test plan

- [x] `go test ./...` — three new tests cover injection through `Middleware`, standalone `InjectLogger` without `RequestID`, and the nil-base safety path.
- [x] `gofmt -s`, `go vet`, `golangci-lint run` clean.
- [x] Backwards compatible: existing callers of `Middleware(log)` need no changes; the only behavior change is that `FromContext` inside handlers now returns the configured logger instead of falling back to `unknown`.


Made with [Cursor](https://cursor.com)