### PR TITLE
fix(logging): stop syncing inside NewLogger and cache FromContext fallback

### DIFF
--- a/logging/context.go
+++ b/logging/context.go
@@ -2,6 +2,7 @@ package logging
 
 import (
 	"context"
+	"sync"
 
 	"go.uber.org/zap"
 )
@@ -10,12 +11,32 @@ type loggerKeyType int
 
 const loggerKey loggerKeyType = iota
 
+var (
+	fallbackLoggerOnce sync.Once
+	fallbackLogger     *zap.SugaredLogger
+)
+
+// fallback returns a process-wide "unknown" logger, built lazily on first
+// use. Caching avoids re-allocating a fresh zap core on every FromContext
+// miss (which previously also triggered a spurious Sync() per call).
+func fallback() *zap.SugaredLogger {
+	fallbackLoggerOnce.Do(func() {
+		fallbackLogger = Must(NewLogger("unknown"))
+	})
+	return fallbackLogger
+}
+
 // NewContext wraps a context with a logger with default fields.
 func NewContext(ctx context.Context, logger *zap.SugaredLogger, fields ...interface{}) context.Context {
 	return context.WithValue(ctx, loggerKey, logger.With(fields...))
 }
 
 // FromContext returns a logger stored in a context.
+//
+// If the context has no logger, FromContext returns a process-wide
+// "unknown" fallback logger. The fallback is constructed once and reused,
+// so repeated FromContext calls on bare contexts do not re-allocate a
+// fresh zap core each time.
 func FromContext(ctx context.Context) *zap.SugaredLogger {
 	if ctx == nil {
 		ctx = context.TODO()
@@ -25,5 +46,5 @@ func FromContext(ctx context.Context) *zap.SugaredLogger {
 		return ctxLogger
 	}
 
-	return Must(NewLogger("unknown"))
+	return fallback()
 }

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -1,12 +1,25 @@
 package logging
 
 import (
+	"errors"
 	"fmt"
+	"syscall"
 
 	"go.uber.org/zap"
 )
 
-// NewLogger creates a production zap logger tagged with the given service name.
+// NewLogger creates a production zap logger tagged with the given service
+// name.
+//
+// Callers should arrange to flush the logger at process exit themselves,
+// typically with:
+//
+//	log := logging.Must(logging.NewLogger("svc"))
+//	defer logging.Sync(log)
+//
+// Note that zap's Sync() returns syscall.EINVAL or syscall.ENOTTY when the
+// underlying writer is a non-syncable stream such as stderr/stdout (common
+// under Linux/Docker). Those errors are benign; use [Sync] to ignore them.
 func NewLogger(serviceName string) (*zap.SugaredLogger, error) {
 	config := zap.NewProductionConfig()
 	config.Level.SetLevel(zap.DebugLevel)
@@ -15,13 +28,6 @@ func NewLogger(serviceName string) (*zap.SugaredLogger, error) {
 	if err != nil {
 		return nil, fmt.Errorf("logger create: %w", err)
 	}
-
-	// defer a func so we can check the error.
-	defer func() {
-		if err := logger.Sync(); err != nil {
-			logger.Debug("could not sync logger", zap.Error(err))
-		}
-	}()
 
 	return logger.Sugar(), nil
 }
@@ -33,4 +39,24 @@ func Must(log *zap.SugaredLogger, err error) *zap.SugaredLogger {
 	}
 
 	return log
+}
+
+// Sync flushes any buffered log entries, ignoring the benign EINVAL/ENOTTY
+// errors that zap returns when the underlying writer is stderr/stdout (or
+// any other non-syncable stream). It is intended to be used as
+// `defer logging.Sync(log)` at process exit.
+func Sync(logger *zap.SugaredLogger) {
+	if logger == nil {
+		return
+	}
+	if err := logger.Sync(); err != nil && !isBenignSyncErr(err) {
+		logger.Debugw("could not sync logger", "error", err)
+	}
+}
+
+// isBenignSyncErr reports whether err is one of the well-known errors that
+// Sync returns when called on stdout/stderr-backed cores. Those streams
+// cannot be fsync'd, so the error carries no useful signal.
+func isBenignSyncErr(err error) bool {
+	return errors.Is(err, syscall.EINVAL) || errors.Is(err, syscall.ENOTTY)
 }

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -1,0 +1,81 @@
+package logging
+
+import (
+	"context"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestFromContextFallbackIsCached verifies that FromContext returns the
+// same fallback logger instance across multiple calls when the context
+// has no logger attached. Re-allocating on every miss was the source of
+// repeated startup log spam in production.
+func TestFromContextFallbackIsCached(t *testing.T) {
+	first := FromContext(context.Background())
+	second := FromContext(context.Background())
+	third := FromContext(nil) //nolint:staticcheck // exercising the nil branch
+
+	if first == nil {
+		t.Fatal("FromContext returned nil")
+	}
+	if first != second || second != third {
+		t.Errorf("FromContext returned different instances: %p %p %p", first, second, third)
+	}
+}
+
+// TestNewLoggerNoSyncDebugLine verifies that constructing a logger does
+// not emit the historical "could not sync logger" debug line. We capture
+// os.Stderr (which the production zap config writes to) for the duration
+// of the call and assert the line is absent.
+func TestNewLoggerNoSyncDebugLine(t *testing.T) {
+	out := captureStderr(t, func() {
+		log, err := NewLogger("test-no-sync")
+		if err != nil {
+			t.Fatalf("NewLogger: %v", err)
+		}
+		if log == nil {
+			t.Fatal("nil logger")
+		}
+	})
+
+	if strings.Contains(out, "could not sync logger") {
+		t.Errorf("NewLogger emitted spurious sync debug line: %q", out)
+	}
+	if strings.TrimSpace(out) != "" {
+		t.Errorf("NewLogger wrote unexpected output to stderr at construction: %q", out)
+	}
+}
+
+// captureStderr redirects os.Stderr through an os.Pipe for the duration
+// of fn, then returns whatever was written. zap's "stderr" sink resolves
+// os.Stderr at Build time, so swapping it before calling fn is enough to
+// intercept what NewLogger writes during construction.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stderr
+	os.Stderr = w
+
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+
+	defer func() {
+		os.Stderr = orig
+	}()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close pipe: %v", err)
+	}
+	return <-done
+}


### PR DESCRIPTION
`NewLogger` deferred `Sync()` inside the constructor, so every call attempted a sync immediately and emitted a `"could not sync logger"` debug line on Linux/Docker (stderr `Sync()` returns `EINVAL`). `FromContext` also rebuilt a fresh zap core on every miss, amplifying the noise (14+ lines per recommender startup).

Removed the in-constructor defer (callers should `defer logging.Sync(log)` at process exit; helper ignores benign `EINVAL`/`ENOTTY`) and cached the `"unknown"` fallback via `sync.Once` so `FromContext` reuses one instance on misses.

Made with [Cursor](https://cursor.com)