### PR TITLE
fix(logging): remove deprecated chi middleware.RealIP

### DIFF
--- a/logging/middleware.go
+++ b/logging/middleware.go
@@ -21,7 +21,6 @@ import (
 // constructs when the context has no logger.
 func Middleware(log *zap.Logger) func(next http.Handler) http.Handler {
 	return chi.Chain(
-		middleware.RealIP,
 		middleware.RequestID,
 		InjectLogger(log.Sugar()),
 		Handler(log),


### PR DESCRIPTION
## Summary

Removes the deprecated `middleware.RealIP` from the `logging.Middleware` chi chain (`logging/middleware.go`).

Chi deprecated `RealIP` because it rewrites `r.RemoteAddr` from spoofable proxy headers (`X-Forwarded-For` / `X-Real-IP` / `True-Client-IP`) whether or not your infrastructure actually sets them — see GHSA-3fxj-6jh8-hvhx, GHSA-rjr7-jggh-pgcp, GHSA-9g5q-2w5x-hmxf. A library can't assume its consumers sit behind a trusted proxy, so removal is the correct fix rather than a `//nolint` suppression (which would just defer a hard break when chi removes the symbol).

## Behavior change

The logged `http.remote` field is now the direct TCP peer (e.g. your load balancer) instead of a client IP derived from proxy headers. Consumers who need the real client IP behind a proxy should add their own trusted-proxy middleware ahead of this chain.

## Verification

- `go build ./...` — OK
- `go test ./logging/` — passes
- `golangci-lint run ./logging/` — 0 issues (SA1019 resolved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)