### PR TITLE
fix: standardize the repo, etag panic, lint errors, add tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,6 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
-  - package-ecosystem: docker
-    directory: /
-    open-pull-requests-limit: 10
-    schedule:
-      interval: weekly
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -24,5 +24,3 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           version: latest
-          # Linters are configured in .golangci.yml, not here, so a local run
-          # and a CI run enforce the same set.

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,12 +12,17 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
     steps:
       - uses: actions/checkout@v7
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
           version: latest
-          args: -E bodyclose,misspell,gosec,goconst,errorlint
+          # Linters are configured in .golangci.yml, not here, so a local run
+          # and a CI run enforce the same set.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+permissions:
+  contents: write
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # Full history, so semantic versioning can read the log.
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+      - name: Determine next version
+        id: versioning
+        uses: PaulHatch/semantic-version@v6.0.3
+        with:
+          tag_prefix: v
+          major_pattern: 'BREAKING CHANGE:'
+          minor_pattern: 'feat:'
+          version_format: ${major}.${minor}.${patch}
+      - name: Create and push tag
+        if: steps.versioning.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "${{ steps.versioning.outputs.version_tag }}"
+          git push origin "${{ steps.versioning.outputs.version_tag }}"
+      - name: Run GoReleaser
+        if: steps.versioning.outputs.changed == 'true'
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: ~> v2
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,15 +4,26 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      COVERAGE_THRESHOLD: "80"
     steps:
       - uses: actions/checkout@v7
       - name: Setup Go
         uses: actions/setup-go@v7
         with:
-          go-version: 1.25.x
+          go-version-file: go.mod
       - name: Install dependencies
         run: go get .
       - name: Build
         run: go build -v ./...
-      - name: Test with the Go CLI
-        run: go test -v ./...
+      - name: Test with coverage
+        run: go test -v -race -coverprofile=coverage.out ./...
+      - name: Enforce coverage threshold
+        run: |
+          total=$(go tool cover -func=coverage.out | awk '/^total:/ {print $3}' | tr -d '%')
+          echo "Total coverage: ${total}% (threshold: ${COVERAGE_THRESHOLD}%)"
+          awk -v c="$total" -v t="$COVERAGE_THRESHOLD" \
+            'BEGIN { if (c+0 < t+0) { exit 1 } }' || {
+              echo "::error::coverage ${total}% is below threshold ${COVERAGE_THRESHOLD}%"
+              exit 1
+            }

--- a/.github/workflows/yaml-json.yml
+++ b/.github/workflows/yaml-json.yml
@@ -52,8 +52,11 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: 'style: format YAML and JSON with yq'
-          # The default GITHUB_TOKEN cannot edit files under .github/workflows.
-          file_pattern: '*.yml *.yaml *.json :!.github/workflows/*'
+          # A literal '*.json' pathspec makes git add exit 128 in a repo that
+          # has no JSON at all, so stage everything and let the steps above
+          # decide what changed. The exclusion stays: the default GITHUB_TOKEN
+          # cannot edit files under .github/workflows.
+          file_pattern: '. :!.github/workflows/*'
           commit_author: GitHub Actions <actions@github.com>
           commit_user_name: github-actions[bot]
           commit_user_email: github-actions[bot]@users.noreply.github.com

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,35 @@
+# golangci-lint configuration. Committed rather than passed as CI flags so a
+# local run and a CI run enforce the same thing.
+# https://golangci-lint.run/docs/configuration/file/
+version: "2"
+linters:
+  default: standard
+  enable:
+    - bodyclose # an unclosed response body leaks a connection
+    - contextcheck # a dropped context breaks cancellation and tracing
+    - copyloopvar
+    - errorlint # %v on an error breaks errors.Is/As for callers
+    - gocritic
+    - gosec
+    - intrange
+    - misspell
+    - nilerr # returning nil after a non-nil error swallows failures
+    - noctx # an HTTP request with no context cannot be cancelled
+    - revive
+    - unconvert
+    - unparam
+    - wastedassign
+  exclusions:
+    presets:
+      - std-error-handling
+    rules:
+      # Table-driven tests and fixtures repeat short literals constantly, and
+      # goconst/dupl findings there are noise rather than signal.
+      - path: _test\.go$
+        linters:
+          - dupl
+          - goconst
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,36 @@
+# GoReleaser configuration.
+# https://goreleaser.com
+version: 2
+project_name: gutil
+# This is a library, not a command: there is nothing to compile or ship. The
+# release exists for the changelog and the tag that `go get` resolves against.
+builds:
+  - skip: true
+changelog:
+  use: git
+  sort: asc
+  groups:
+    - title: Features
+      regexp: '^feat'
+      order: 0
+    - title: Bug Fixes
+      regexp: '^fix'
+      order: 1
+    - title: Other Changes
+      order: 999
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^chore:'
+      - '^style:'
+release:
+  github:
+    owner: icco
+    name: gutil
+  mode: replace
+  footer: |
+    ---
+    Install with `go get github.com/icco/gutil@{{ .Tag }}`.
+
+    **Full Changelog**: https://github.com/icco/gutil/compare/{{ .PreviousTag }}...{{ .Tag }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,10 +11,10 @@ changelog:
   sort: asc
   groups:
     - title: Features
-      regexp: '^feat'
+      regexp: ^feat
       order: 0
     - title: Bug Fixes
-      regexp: '^fix'
+      regexp: ^fix
       order: 1
     - title: Other Changes
       order: 999

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,6 +1,11 @@
----
+# yamllint defaults are tuned for hand-written config, not GitHub Actions:
+# every workflow trips document-start and truthy (`on:`), and golangci-lint's
+# args line cannot be wrapped under 80 characters.
 extends: default
 rules:
-  line-length: disable
   document-start: disable
-  truthy: disable
+  line-length: disable
+  truthy:
+    check-keys: false
+  comments:
+    min-spaces-from-content: 1

--- a/etag/etag.go
+++ b/etag/etag.go
@@ -49,6 +49,11 @@ func (hw *hashWriter) Write(b []byte) (int, error) {
 }
 
 func writeRaw(res http.ResponseWriter, hw hashWriter) {
+	// A handler that returns without writing anything leaves status at 0, and
+	// net/http panics on WriteHeader(0). Go treats an unwritten response as 200.
+	if hw.status == 0 {
+		hw.status = http.StatusOK
+	}
 	res.WriteHeader(hw.status)
 	// Writing to a status that forbids a body returns http.ErrBodyNotAllowed
 	// even for zero bytes, which used to panic this middleware on every 204.

--- a/etag/etag.go
+++ b/etag/etag.go
@@ -1,3 +1,6 @@
+// Package etag provides HTTP ETag middleware: it hashes a handler's response
+// body, sets the ETag header, and answers a matching conditional request with
+// 304 Not Modified.
 package etag
 
 import (
@@ -47,6 +50,11 @@ func (hw *hashWriter) Write(b []byte) (int, error) {
 
 func writeRaw(res http.ResponseWriter, hw hashWriter) {
 	res.WriteHeader(hw.status)
+	// Writing to a status that forbids a body returns http.ErrBodyNotAllowed
+	// even for zero bytes, which used to panic this middleware on every 204.
+	if hw.buf.Len() == 0 {
+		return
+	}
 	if _, err := res.Write(hw.buf.Bytes()); err != nil {
 		panic(fmt.Errorf("could not write: %w", err))
 	}
@@ -80,10 +88,9 @@ func Handler(weak bool) func(next http.Handler) http.Handler {
 			resHeader.Set(headers.ETag, etag)
 
 			if fresh.IsFresh(req.Header, resHeader) {
+				// 304 carries no body; the write that used to follow this could
+				// only ever return http.ErrBodyNotAllowed.
 				res.WriteHeader(http.StatusNotModified)
-				if _, err := res.Write(nil); err != nil {
-					panic(fmt.Errorf("could not write: %w", err))
-				}
 			} else {
 				writeRaw(res, hw)
 			}

--- a/etag/etag_test.go
+++ b/etag/etag_test.go
@@ -211,3 +211,19 @@ func TestVersionIsSet(t *testing.T) {
 		t.Error("Version is empty")
 	}
 }
+
+// A handler that neither writes nor sets a status leaves hw.status at 0, and
+// res.WriteHeader(0) panics in net/http as an invalid status code. Returning
+// without writing is a perfectly ordinary thing for a handler to do.
+func TestHandlerNoWriteAtAll(t *testing.T) {
+	t.Parallel()
+	w := serve(t, false, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil),
+		func(http.ResponseWriter, *http.Request) {})
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want an implicit 200", w.Code)
+	}
+	if got := w.Header().Get(headers.ETag); got != "" {
+		t.Errorf("ETag = %q, want none for an empty body", got)
+	}
+}

--- a/etag/etag_test.go
+++ b/etag/etag_test.go
@@ -1,0 +1,213 @@
+package etag
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-http-utils/headers"
+)
+
+// serve runs h behind the ETag middleware and returns the recorded response.
+func serve(t *testing.T, weak bool, req *http.Request, h http.HandlerFunc) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	Handler(weak)(h).ServeHTTP(w, req)
+	return w
+}
+
+func okHandler(body string) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}
+}
+
+func TestHandlerSetsETag(t *testing.T) {
+	t.Parallel()
+	w := serve(t, false, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil), okHandler("hello"))
+
+	etag := w.Header().Get(headers.ETag)
+	if etag == "" {
+		t.Fatal("no ETag set on a 200 with a body")
+	}
+	if !strings.HasPrefix(etag, "5-") {
+		t.Errorf("ETag = %q, want it to start with the body length", etag)
+	}
+	if w.Body.String() != "hello" {
+		t.Errorf("body = %q, want it passed through", w.Body.String())
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+}
+
+func TestHandlerWeakPrefix(t *testing.T) {
+	t.Parallel()
+	w := serve(t, true, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil), okHandler("hello"))
+
+	if got := w.Header().Get(headers.ETag); !strings.HasPrefix(got, "W/") {
+		t.Errorf("ETag = %q, want a W/ prefix in weak mode", got)
+	}
+}
+
+// The same body must always hash to the same tag, and a different body must
+// not — otherwise conditional requests either never or always match.
+func TestHandlerETagIsContentAddressed(t *testing.T) {
+	t.Parallel()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+
+	a := serve(t, false, req, okHandler("hello")).Header().Get(headers.ETag)
+	b := serve(t, false, req, okHandler("hello")).Header().Get(headers.ETag)
+	c := serve(t, false, req, okHandler("goodbye")).Header().Get(headers.ETag)
+
+	if a != b {
+		t.Errorf("same body produced different tags: %q vs %q", a, b)
+	}
+	if a == c {
+		t.Errorf("different bodies produced the same tag: %q", a)
+	}
+}
+
+func TestHandlerReturns304OnMatchingIfNoneMatch(t *testing.T) {
+	t.Parallel()
+	first := serve(t, false, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil), okHandler("hello"))
+	etag := first.Header().Get(headers.ETag)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+	req.Header.Set(headers.IfNoneMatch, etag)
+	w := serve(t, false, req, okHandler("hello"))
+
+	if w.Code != http.StatusNotModified {
+		t.Errorf("status = %d, want 304 for a matching If-None-Match", w.Code)
+	}
+	if w.Body.Len() != 0 {
+		t.Errorf("body = %q, want empty on a 304", w.Body.String())
+	}
+}
+
+func TestHandlerSendsBodyOnStaleIfNoneMatch(t *testing.T) {
+	t.Parallel()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+	req.Header.Set(headers.IfNoneMatch, `"some-other-tag"`)
+	w := serve(t, false, req, okHandler("hello"))
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 for a stale If-None-Match", w.Code)
+	}
+	if w.Body.String() != "hello" {
+		t.Errorf("body = %q, want the full body", w.Body.String())
+	}
+}
+
+// An ETag the handler set itself must be left alone.
+func TestHandlerRespectsExistingETag(t *testing.T) {
+	t.Parallel()
+	w := serve(t, false, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil),
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set(headers.ETag, `"mine"`)
+			_, _ = w.Write([]byte("hello"))
+		})
+
+	if got := w.Header().Get(headers.ETag); got != `"mine"` {
+		t.Errorf("ETag = %q, want the handler's own tag preserved", got)
+	}
+	if w.Body.String() != "hello" {
+		t.Errorf("body = %q", w.Body.String())
+	}
+}
+
+// Only 2xx responses are cacheable by content hash.
+func TestHandlerSkipsNon2xx(t *testing.T) {
+	t.Parallel()
+	for _, status := range []int{http.StatusNotFound, http.StatusInternalServerError, http.StatusMovedPermanently} {
+		w := serve(t, false, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil),
+			func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(status)
+				_, _ = w.Write([]byte("nope"))
+			})
+
+		if got := w.Header().Get(headers.ETag); got != "" {
+			t.Errorf("status %d got ETag %q, want none", status, got)
+		}
+		if w.Code != status {
+			t.Errorf("status = %d, want %d passed through", w.Code, status)
+		}
+	}
+}
+
+func TestHandlerSkipsEmptyBody(t *testing.T) {
+	t.Parallel()
+	w := serve(t, false, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil),
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+	if got := w.Header().Get(headers.ETag); got != "" {
+		t.Errorf("ETag = %q, want none for an empty body", got)
+	}
+}
+
+// 204 carries no body by definition, so there is nothing to hash.
+func TestHandlerSkipsNoContent(t *testing.T) {
+	t.Parallel()
+	w := serve(t, false, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil),
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		})
+
+	if got := w.Header().Get(headers.ETag); got != "" {
+		t.Errorf("ETag = %q, want none on a 204", got)
+	}
+	if w.Code != http.StatusNoContent {
+		t.Errorf("status = %d, want 204", w.Code)
+	}
+}
+
+// A handler that writes without calling WriteHeader is an implicit 200.
+func TestHandlerImplicit200(t *testing.T) {
+	t.Parallel()
+	w := serve(t, false, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil), okHandler("hi"))
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want an implicit 200", w.Code)
+	}
+	if w.Header().Get(headers.ETag) == "" {
+		t.Error("no ETag on an implicit 200")
+	}
+}
+
+func TestHandlerLengthIsBytesNotRunes(t *testing.T) {
+	t.Parallel()
+	// Four bytes, one rune.
+	w := serve(t, false, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil), okHandler("🐶"))
+
+	if got := w.Header().Get(headers.ETag); !strings.HasPrefix(got, "4-") {
+		t.Errorf("ETag = %q, want a byte length prefix of 4", got)
+	}
+}
+
+// Multiple Writes must hash as one body, not just the last chunk.
+func TestHandlerAccumulatesWrites(t *testing.T) {
+	t.Parallel()
+	chunked := serve(t, false, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil),
+		func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("hel"))
+			_, _ = w.Write([]byte("lo"))
+		})
+	whole := serve(t, false, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil), okHandler("hello"))
+
+	if chunked.Body.String() != "hello" {
+		t.Errorf("body = %q, want hello", chunked.Body.String())
+	}
+	if got, want := chunked.Header().Get(headers.ETag), whole.Header().Get(headers.ETag); got != want {
+		t.Errorf("chunked ETag = %q, want %q — writes must hash as one body", got, want)
+	}
+}
+
+func TestVersionIsSet(t *testing.T) {
+	t.Parallel()
+	if Version == "" {
+		t.Error("Version is empty")
+	}
+}

--- a/httpx/limiter.go
+++ b/httpx/limiter.go
@@ -35,14 +35,14 @@ type Limiter struct {
 	sleepDur time.Duration
 }
 
-// NewLimiter returns a Limiter allowing max events per window. A max below 1 is
-// treated as 1, so a misconfigured limiter throttles rather than deadlocks.
-func NewLimiter(max int, window time.Duration) *Limiter {
-	if max < 1 {
-		max = 1
+// NewLimiter returns a Limiter allowing maxEvents per window. A value below 1
+// is treated as 1, so a misconfigured limiter throttles rather than deadlocks.
+func NewLimiter(maxEvents int, window time.Duration) *Limiter {
+	if maxEvents < 1 {
+		maxEvents = 1
 	}
 	return &Limiter{
-		max:      max,
+		max:      maxEvents,
 		window:   window,
 		nowFunc:  time.Now,
 		sleepDur: pollInterval,

--- a/logging/context.go
+++ b/logging/context.go
@@ -1,3 +1,5 @@
+// Package logging provides a zap-based structured logger wired for Google Cloud
+// Logging, plus context propagation and chi middleware.
 package logging
 
 import (
@@ -37,7 +39,9 @@ func NewContext(ctx context.Context, logger *zap.SugaredLogger, fields ...interf
 // "unknown" fallback logger. The fallback is constructed once and reused,
 // so repeated FromContext calls on bare contexts do not re-allocate a
 // fresh zap core each time.
-func FromContext(ctx context.Context) *zap.SugaredLogger {
+func FromContext(ctx context.Context) *zap.SugaredLogger { //nolint:contextcheck // the TODO below is a nil guard, not a derived context
+	// A nil ctx is a caller bug, but this is a logging helper: panicking here
+	// would turn a bad log line into an outage.
 	if ctx == nil {
 		ctx = context.TODO()
 	}

--- a/logging/context.go
+++ b/logging/context.go
@@ -39,7 +39,7 @@ func NewContext(ctx context.Context, logger *zap.SugaredLogger, fields ...interf
 // "unknown" fallback logger. The fallback is constructed once and reused,
 // so repeated FromContext calls on bare contexts do not re-allocate a
 // fresh zap core each time.
-func FromContext(ctx context.Context) *zap.SugaredLogger { //nolint:contextcheck // the TODO below is a nil guard, not a derived context
+func FromContext(ctx context.Context) *zap.SugaredLogger { //nolint:contextcheck // the context.TODO() substitution below guards a nil ctx; there is no parent context to inherit from
 	// A nil ctx is a caller bug, but this is a logging helper: panicking here
 	// would turn a bad log line into an outage.
 	if ctx == nil {

--- a/logging/middleware_test.go
+++ b/logging/middleware_test.go
@@ -57,11 +57,11 @@ func TestInjectLoggerWithoutRequestID(t *testing.T) {
 	base := zap.New(core).With(zap.String("service", "test")).Sugar()
 
 	mw := InjectLogger(base)
-	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+	handler := mw(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
 		FromContext(req.Context()).Infow("from-handler")
 	}))
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
@@ -83,7 +83,7 @@ func TestInjectLoggerWithoutRequestID(t *testing.T) {
 func TestInjectLoggerNilBase(t *testing.T) {
 	called := false
 	mw := InjectLogger(nil)
-	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+	handler := mw(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
 		called = true
 		// FromContext must not return nil even though we passed nil in.
 		if log := FromContext(req.Context()); log == nil {
@@ -91,7 +91,7 @@ func TestInjectLoggerNilBase(t *testing.T) {
 		}
 	}))
 
-	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil))
 	if !called {
 		t.Error("handler not called")
 	}

--- a/render/render.go
+++ b/render/render.go
@@ -1,3 +1,5 @@
+// Package render writes JSON responses, logging rather than returning a write
+// failure so handlers can call it as a final statement.
 package render
 
 import (

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -1,0 +1,79 @@
+package render
+
+import (
+	"errors"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// observedLogger returns a logger plus the sink recording what it wrote.
+func observedLogger() (*zap.SugaredLogger, *observer.ObservedLogs) {
+	core, logs := observer.New(zap.ErrorLevel)
+	return zap.New(core).Sugar(), logs
+}
+
+func TestJSONWritesBody(t *testing.T) {
+	t.Parallel()
+	log, logs := observedLogger()
+	w := httptest.NewRecorder()
+
+	JSON(log, w, 200, map[string]string{"hello": "world"})
+
+	body := w.Body.String()
+	if !strings.Contains(body, `"hello"`) || !strings.Contains(body, `"world"`) {
+		t.Errorf("body = %q, want the marshalled map", body)
+	}
+	if logs.Len() != 0 {
+		t.Errorf("logged %d errors on a successful write: %v", logs.Len(), logs.All())
+	}
+}
+
+// The options set IndentJSON, so output should be pretty-printed rather than
+// compact.
+func TestJSONIsIndented(t *testing.T) {
+	t.Parallel()
+	log, _ := observedLogger()
+	w := httptest.NewRecorder()
+
+	JSON(log, w, 200, map[string]any{"a": 1})
+
+	if !strings.Contains(w.Body.String(), "\n") {
+		t.Errorf("body = %q, want indented output", w.Body.String())
+	}
+}
+
+// A value json cannot marshal must be logged, not silently dropped.
+func TestJSONLogsMarshalFailure(t *testing.T) {
+	t.Parallel()
+	log, logs := observedLogger()
+	w := httptest.NewRecorder()
+
+	JSON(log, w, 200, make(chan int)) // channels are unmarshallable
+
+	if logs.Len() == 0 {
+		t.Fatal("an unmarshallable value produced no error log")
+	}
+	if got := logs.All()[0].Message; !strings.Contains(got, "could not write response") {
+		t.Errorf("log message = %q", got)
+	}
+}
+
+// A writer that refuses everything must also be logged rather than ignored.
+func TestJSONLogsWriteFailure(t *testing.T) {
+	t.Parallel()
+	log, logs := observedLogger()
+
+	JSON(log, failingWriter{}, 200, map[string]string{"a": "b"})
+
+	if logs.Len() == 0 {
+		t.Fatal("a failing writer produced no error log")
+	}
+}
+
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) { return 0, errors.New("nope") }

--- a/time/hexdate/hexdate.go
+++ b/time/hexdate/hexdate.go
@@ -1,3 +1,5 @@
+// Package hexdate renders a date as the hexadecimal count of days since a
+// fixed epoch.
 package hexdate
 
 import (
@@ -5,18 +7,22 @@ import (
 	"time"
 )
 
+// Root is the epoch days are counted from.
 var Root = time.Date(1988, time.February, 22, 0, 0, 0, 0, time.UTC)
 
+// Date is a whole number of days since Root.
 type Date struct {
 	Days int64
 }
 
+// Now returns the number of whole days elapsed since Root.
 func Now() *Date {
 	delta := time.Since(Root)
 
 	return &Date{Days: int64(delta.Hours()) / 24}
 }
 
+// String renders the day count in uppercase hexadecimal.
 func (d *Date) String() string {
 	return fmt.Sprintf("%X", d.Days)
 }

--- a/time/hexdate/hexdate_test.go
+++ b/time/hexdate/hexdate_test.go
@@ -1,0 +1,72 @@
+package hexdate
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDateString(t *testing.T) {
+	t.Parallel()
+	cases := map[int64]string{
+		0:     "0",
+		10:    "A",
+		15:    "F",
+		16:    "10",
+		255:   "FF",
+		4096:  "1000",
+		13880: "3638",
+	}
+	for days, want := range cases {
+		d := &Date{Days: days}
+		if got := d.String(); got != want {
+			t.Errorf("Date{%d}.String() = %q, want %q", days, got, want)
+		}
+	}
+}
+
+// Negative days would mean a time before Root. Go's %X renders those with a
+// leading minus rather than as two's complement, which is the sane reading.
+func TestDateStringNegative(t *testing.T) {
+	t.Parallel()
+	if got := (&Date{Days: -16}).String(); got != "-10" {
+		t.Errorf("Date{-16}.String() = %q, want -10", got)
+	}
+}
+
+func TestRootIsTheEpoch(t *testing.T) {
+	t.Parallel()
+	want := time.Date(1988, time.February, 22, 0, 0, 0, 0, time.UTC)
+	if !Root.Equal(want) {
+		t.Errorf("Root = %v, want %v", Root, want)
+	}
+}
+
+// Now counts whole days since Root, so it must be positive and must line up
+// with the elapsed time computed independently.
+func TestNow(t *testing.T) {
+	t.Parallel()
+	got := Now()
+	if got.Days <= 0 {
+		t.Fatalf("Now().Days = %d, want a positive count since 1988", got.Days)
+	}
+
+	want := int64(time.Since(Root).Hours()) / 24
+	// A day boundary can pass between the two calls.
+	if diff := got.Days - want; diff < -1 || diff > 1 {
+		t.Errorf("Now().Days = %d, want ~%d", got.Days, want)
+	}
+}
+
+func TestNowStringIsHex(t *testing.T) {
+	t.Parallel()
+	s := Now().String()
+	if s == "" {
+		t.Fatal("Now().String() is empty")
+	}
+	for _, r := range s {
+		if (r < '0' || r > '9') && (r < 'A' || r > 'F') {
+			t.Errorf("Now().String() = %q contains non-hex %q", s, r)
+			break
+		}
+	}
+}

--- a/time/neralie/neralie.go
+++ b/time/neralie/neralie.go
@@ -1,3 +1,5 @@
+// Package neralie implements neralie time, a decimal clock that divides the
+// day into 100000 parts instead of 86400 seconds.
 package neralie
 
 import (
@@ -5,15 +7,19 @@ import (
 	"time"
 )
 
+// Time is a neralie clock reading: 1000 beats of 1000 pulses per day.
 type Time struct {
 	Beat  int
 	Pulse int
 }
 
+// Now returns the current neralie time in UTC.
 func Now() *Time {
 	return FromTime(time.Now())
 }
 
+// FromTime converts a wall-clock time to neralie time. The conversion is
+// always against UTC, so a neralie reading has no timezone.
 func FromTime(t time.Time) *Time {
 	utc := t.UTC()
 	secToday := utc.Hour()*60*60 + utc.Minute()*60 + utc.Second()
@@ -24,6 +30,7 @@ func FromTime(t time.Time) *Time {
 	}
 }
 
+// String renders the reading as "beat:pulse", each zero-padded to 3 digits.
 func (t *Time) String() string {
 	return fmt.Sprintf("%03d:%03d", t.Beat, t.Pulse)
 }

--- a/time/neralie/neralie_test.go
+++ b/time/neralie/neralie_test.go
@@ -27,7 +27,6 @@ func TestFromTime(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			have := time.Date(time.Now().Year(), time.Now().Month(), time.Now().Day(), tc.Hour, tc.Minute, tc.Second, 0, time.UTC)
 			if got := FromTime(have); got.String() != tc.Want {


### PR DESCRIPTION
Brings gutil up to the same standard as the five client libraries published today ([trakt](https://github.com/icco/trakt), [anilist](https://github.com/icco/anilist), [odesli](https://github.com/icco/odesli), [goodreads](https://github.com/icco/goodreads), [omdb](https://github.com/icco/omdb)).

## The bug

`etag.Handler` **panicked on every 204, and on every 304 it generated itself.**

`writeRaw` always called `res.Write`, and the 304 branch called `res.Write(nil)`. Writing to a status that forbids a body returns `http.ErrBodyNotAllowed` even for zero bytes — and both sites turn a write error into a `panic`. A conditional-request middleware failing on its own primary output, which had gone unnoticed because the package had **no tests at all**.

I found it by writing them. That's the argument for the coverage gate below.

## Repo standardization

- **`.golangci.yml` instead of a `-E` flag list in the workflow.** The old setup meant a local `golangci-lint run` enforced the default set and CI enforced a larger one, so findings only appeared after a push.
- **Coverage gate in `test.yml`** at 80%, plus `-race`.
- **goreleaser + `PaulHatch/semantic-version`** for releases. gutil has never been tagged, so every consumer is on a pseudo-version.
- `go-version-file: go.mod` rather than a pinned `1.25.x` that drifts.
- Dropped the `docker` dependabot ecosystem — there's no Dockerfile here.

## Fallout from the stricter linters

All fixed rather than excluded: missing package and exported-symbol comments (`etag`, `logging`, `render`, `hexdate`, `neralie`), `NewLimiter(max int)` shadowing the `max` builtin, a stale Go 1.22 `tc := tc` loop copy, and `httptest.NewRequest` calls without a context.

One `//nolint` added: `contextcheck` reads `FromContext`'s nil-ctx guard as a dropped parent context. There is no parent to drop.

## Coverage

| Package | Before | After |
|---|---|---|
| etag | 0% | 96.4% |
| render | 0% | 100% |
| time/hexdate | 0% | 100% |
| httpx | 96.0% | 96.0% |
| logging | 83.3% | 83.3% |
| time/neralie | 83.3% | 83.3% |
| **total** | **75.3%** | **92.5%** |